### PR TITLE
add Value type

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,13 @@ Create a *fixed* length (in bytes) string codec.
 
 Create a variable length string codec. This codec uses `VarBuffer` (buffer will be created from string with given `encoding`).
 
-### Bound(itemCodec, checkValue)
+### Bound(itemCodec, checkValueCallback)
 
-Return a codec that will check value before encode and after decode. `checkValue` should throw error if value is wrong.
+Return a codec that will call `checkValueCallback` before encode and after decode. `checkValueCallback` should throw error if the given `value` is wrong.
+
+### Value(itemCodec, constantValue)
+
+Return a codec that will encode `constantValue` every time (and will throw if given any value other than `constantValue`),  and will decode `constantValue` if it exists (throwing otherwise).
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,3 +38,6 @@ exports.VarString = require('./varstring')
 
 // bound
 exports.Bound = require('./bound')
+
+// value
+exports.Value = require('./value')

--- a/lib/value.js
+++ b/lib/value.js
@@ -1,0 +1,35 @@
+'use strict'
+var util = require('./util')
+
+module.exports = function (valueType, value) {
+  if (!util.isAbstractCodec(valueType)) throw new TypeError('valueType is invalid codec')
+
+  var valueBuffer = valueType.encode(value)
+  var encodeLength = valueBuffer.length
+
+  return {
+    encode: function encode (valueParam, buffer, offset) {
+      if (valueParam !== undefined) throw new TypeError('Value parameter must be undefined')
+      if (buffer) {
+        offset = offset | 0
+        if ((buffer.length - offset) < encodeLength) throw new RangeError('destination buffer is too small')
+        valueBuffer.copy(buffer, offset)
+      } else {
+        buffer = Buffer.from(valueBuffer)
+      }
+      encode.bytes = encodeLength
+      return buffer
+    },
+    decode: function decode (target, offset, end) {
+      offset = offset | 0
+      if ((target.length - offset) < encodeLength) throw new RangeError('not enough data for decode')
+      if (valueBuffer.compare(target, offset, end) !== 0) throw new TypeError('Expected value ' + value)
+      decode.bytes = encodeLength
+      return undefined
+    },
+    encodingLength: function encodingLength (valueParam) {
+      if (valueParam !== undefined) throw new TypeError('Value parameter must be undefined')
+      return encodeLength
+    }
+  }
+}

--- a/test/value.js
+++ b/test/value.js
@@ -1,0 +1,74 @@
+'use strict'
+var test = require('tape').test
+var varstruct = require('../')
+var value = varstruct.Value(varstruct.UInt32BE, 0xdeadbeef)
+
+test('asserts on codec creation', function (t) {
+  t.test('valueType is invalid codec', function (t) {
+    t.throws(function () {
+      varstruct.Value(null)
+    }, /^TypeError: valueType is invalid codec$/)
+    t.end()
+  })
+
+  t.end()
+})
+
+test('encode', function (t) {
+  t.test('value must be undefined', function (t) {
+    t.throws(function () {
+      value.encode(null)
+    }, /^TypeError: Value parameter must be undefined/)
+    t.end()
+  })
+
+  t.test('destination buffer is too small', function (t) {
+    t.throws(function () {
+      value.encode(undefined, Buffer.allocUnsafe(3))
+    }, /^RangeError: destination buffer is too small$/)
+    t.end()
+  })
+
+  t.test('write buffer', function (t) {
+    var result = value.encode()
+    t.same(value.encode.bytes, 4)
+    t.same(result.toString('hex'), 'deadbeef')
+    t.end()
+  })
+
+  t.end()
+})
+
+test('decode', function (t) {
+  t.test('not enough data for decode', function (t) {
+    t.throws(function () {
+      value.decode(Buffer.from('deadbe', 'hex'))
+    }, /^RangeError: not enough data for decode$/)
+    t.end()
+  })
+
+  t.test('read buffers', function (t) {
+    var result = value.decode(Buffer.from('deadbeef', 'hex'))
+    t.same(value.decode.bytes, 4)
+    t.same(result, undefined)
+    t.end()
+  })
+
+  t.end()
+})
+
+test('encodingLength', function (t) {
+  t.test('value must be undefined', function (t) {
+    t.throws(function () {
+      value.encodingLength(null)
+    }, /^TypeError: Value parameter must be undefined/)
+    t.end()
+  })
+
+  t.test('constant length', function (t) {
+    t.same(value.encodingLength(), 4)
+    t.end()
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Proposed usage:

``` js
vstruct.Value(vstruct.UInt32LE, 0xdeadbeef)
```

Alternatives:
``` js
vstruct.Magic(vstruct.UInt32LE, 0xdeadbeef)
vstruct.Constant(vstruct.UInt32LE, 0xdeadbeef)
```

Ref https://github.com/dominictarr/varstruct/issues/10

- [x] Add `Value` to `index.js` exports
- [x] Add tests
- [x] Maybe add preliminary check to ensure `value` *can* be encoded?  Maybe... probably not worth it
- [x] Optimize to avoid any `encoding`
- [x] Decode needs to verify the value is the same

-- Ready to merge