### PR TITLE
numbers: add type check

### DIFF
--- a/lib/numbers.js
+++ b/lib/numbers.js
@@ -20,6 +20,7 @@ exports.create = function (type, length) {
   var read = getRead('read' + type)
 
   function encode (value, buffer, offset) {
+    if (typeof value !== 'number') throw new TypeError('value must be a number')
     if (!buffer) buffer = Buffer.allocUnsafe(length)
     if (!offset) offset = 0
     write.call(buffer, value, offset)

--- a/test/index.js
+++ b/test/index.js
@@ -77,6 +77,13 @@ test('encode', function (t) {
     }, /^TypeError: expected value as object, got null/)
     t.end()
   })
+  
+  t.test('expected number', function (t) {
+    t.throws(function () {
+      varstruct(varstruct.UInt32BE).encode(function () {})
+    }, /^TypeError: value must be a number'/)
+    t.end()
+  })
 
   t.end()
 })


### PR DESCRIPTION
This would bring the number types into feature parity with the other types.

e.g
https://github.com/varstruct/varstruct/blob/master/lib/object.js#L23
https://github.com/varstruct/varstruct/blob/master/lib/vararray.js#L14
https://github.com/varstruct/varstruct/blob/master/lib/varbuffer.js#L13
https://github.com/varstruct/varstruct/blob/master/lib/varstring.js#L13
https://github.com/varstruct/varstruct/blob/master/lib/sequence.js#L21
https://github.com/varstruct/varstruct/blob/master/lib/string.js#L11

If merged,  please release as patch :+1: 