### PR TITLE
Value decoding fix

### DIFF
--- a/lib/value.js
+++ b/lib/value.js
@@ -23,7 +23,7 @@ module.exports = function (valueType, value) {
     decode: function decode (target, offset, end) {
       offset = offset | 0
       if ((target.length - offset) < encodeLength) throw new RangeError('not enough data for decode')
-      if (valueBuffer.compare(target, offset, end) !== 0) throw new TypeError('Expected value ' + value)
+      if (valueBuffer.compare(target, offset, offset + encodeLength) !== 0) throw new TypeError('Expected value ' + value)
       decode.bytes = encodeLength
       return undefined
     },

--- a/lib/value.js
+++ b/lib/value.js
@@ -22,7 +22,8 @@ module.exports = function (valueType, value) {
     },
     decode: function decode (target, offset, end) {
       offset = offset | 0
-      if ((target.length - offset) < encodeLength) throw new RangeError('not enough data for decode')
+      if (end === undefined) end = target.length
+      if (offset + encodeLength > end) throw new RangeError('not enough data for decode')
       if (valueBuffer.compare(target, offset, offset + encodeLength) !== 0) throw new TypeError('Expected value ' + value)
       decode.bytes = encodeLength
       return undefined

--- a/test/value.js
+++ b/test/value.js
@@ -47,6 +47,11 @@ test('decode', function (t) {
     t.end()
   })
 
+  t.test('extra data for decode', function (t) {
+    value.decode(Buffer.from('deadbeefffff', 'hex'))
+    t.end()
+  })
+
   t.test('read buffers', function (t) {
     var result = value.decode(Buffer.from('deadbeef', 'hex'))
     t.same(value.decode.bytes, 4)

--- a/test/value.js
+++ b/test/value.js
@@ -52,7 +52,7 @@ test('decode', function (t) {
     t.end()
   })
 
-  t.test('offset past end', function (t) {
+  t.test('not enough data for decode (w/ offset and end)', function (t) {
     t.throws(function () {
       value.decode(Buffer.from('ffffdeadbeef', 'hex'), 2, 4)
     }, /^RangeError: not enough data for decode$/)

--- a/test/value.js
+++ b/test/value.js
@@ -52,6 +52,13 @@ test('decode', function (t) {
     t.end()
   })
 
+  t.test('offset past end', function (t) {
+    t.throws(function () {
+      value.decode(Buffer.from('ffffdeadbeef', 'hex'), 2, 4)
+    }, /^RangeError: not enough data for decode$/)
+    t.end()
+  })
+
   t.test('read buffers', function (t) {
     var result = value.decode(Buffer.from('deadbeef', 'hex'))
     t.same(value.decode.bytes, 4)


### PR DESCRIPTION
If the `Buffer` given contained more data than necessary,  `Value` types threw unexpectedly.