### PR TITLE
Extra tests and VarMap past-the-end decode

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -2,6 +2,10 @@
 module.exports = function (length) {
   if (typeof length !== 'number') throw new TypeError('length must be a number')
 
+  function _length () {
+    return length
+  }
+
   function encode (value, buffer, offset) {
     if (!Buffer.isBuffer(value)) throw new TypeError('value must be a Buffer instance')
     if (value.length !== length) throw new RangeError('value.length is out of bounds')
@@ -20,5 +24,9 @@ module.exports = function (length) {
   }
 
   encode.bytes = decode.bytes = length
-  return { encode: encode, decode: decode, encodingLength: function () { return length } }
+  return {
+    encode: encode,
+    decode: decode,
+    encodingLength: _length
+  }
 }

--- a/lib/object.js
+++ b/lib/object.js
@@ -12,32 +12,49 @@ module.exports = function (items) {
     return { name: item.name, type: item.type }
   })
 
-  function encodingLength (obj) {
-    return util.size(items, function (item) {
-      return item.type.encodingLength(obj[item.name])
-    })
+  function _length (object) {
+    if (!object) throw new TypeError('Expected object')
+
+    return items.reduce(function (a, item) {
+      var value = object[item.name]
+      return a + item.type.encodingLength(value)
+    }, 0)
   }
 
   return {
-    encode: function encode (value, buffer, offset) {
-      if (typeof value !== 'object' || value === null) throw new TypeError('expected value as object, got ' + value)
-      if (!buffer) buffer = Buffer.allocUnsafe(encodingLength(value))
+    encode: function encode (object, buffer, offset) {
+      if (typeof object !== 'object' || object === null) throw new TypeError('expected value as object, got ' + object)
+
+      var bytes = _length(object)
+      if (!buffer) buffer = Buffer.allocUnsafe(bytes)
+      else if ((buffer.length - offset) < bytes) throw new RangeError('destination buffer is too small')
       if (!offset) offset = 0
-      encode.bytes = util.size(items, function (item, index, loffset) {
-        item.type.encode(value[item.name], buffer, loffset)
-        return item.type.encode.bytes
-      }, offset) - offset
+
+      items.forEach(function (item) {
+        var value = object[item.name]
+
+        item.type.encode(value, buffer, offset)
+        offset += item.type.encode.bytes
+      })
+      encode.bytes = bytes
+
       return buffer
     },
     decode: function decode (buffer, offset, end) {
       if (!offset) offset = 0
-      var obj = {}
-      decode.bytes = util.size(items, function (item, index, loffset) {
-        obj[item.name] = item.type.decode(buffer, loffset, end)
-        return item.type.decode.bytes
-      }, offset) - offset
-      return obj
+      var result = {}
+      var start = offset
+
+      items.forEach(function (item) {
+        var value = item.type.decode(buffer, offset, end)
+        offset += item.type.decode.bytes
+
+        result[item.name] = value
+      })
+      decode.bytes = offset - start
+
+      return result
     },
-    encodingLength: encodingLength
+    encodingLength: _length
   }
 }

--- a/lib/object.js
+++ b/lib/object.js
@@ -23,10 +23,11 @@ module.exports = function (items) {
 
   return {
     encode: function encode (object, buffer, offset) {
+      if (!offset) offset = 0
+
       var bytes = _length(object)
       if (!buffer) buffer = Buffer.allocUnsafe(bytes)
       else if ((buffer.length - offset) < bytes) throw new RangeError('destination buffer is too small')
-      if (!offset) offset = 0
 
       items.forEach(function (item) {
         var value = object[item.name]
@@ -40,6 +41,7 @@ module.exports = function (items) {
     },
     decode: function decode (buffer, offset, end) {
       if (!offset) offset = 0
+
       var result = {}
       var start = offset
 

--- a/lib/object.js
+++ b/lib/object.js
@@ -13,7 +13,7 @@ module.exports = function (items) {
   })
 
   function _length (object) {
-    if (!object) throw new TypeError('Expected object')
+    if (typeof object !== 'object' || object === null) throw new TypeError('Expected Object, got ' + object)
 
     return items.reduce(function (a, item) {
       var value = object[item.name]
@@ -23,8 +23,6 @@ module.exports = function (items) {
 
   return {
     encode: function encode (object, buffer, offset) {
-      if (typeof object !== 'object' || object === null) throw new TypeError('expected value as object, got ' + object)
-
       var bytes = _length(object)
       if (!buffer) buffer = Buffer.allocUnsafe(bytes)
       else if ((buffer.length - offset) < bytes) throw new RangeError('destination buffer is too small')

--- a/lib/string.js
+++ b/lib/string.js
@@ -10,9 +10,11 @@ module.exports = function (length, encoding) {
 
   function encode (value, buffer, offset) {
     if (typeof value !== 'string') throw new TypeError('value must be a string')
+
     if (Buffer.byteLength(value, encoding) !== length) throw new RangeError('value.length is out of bounds')
     if (!buffer) return Buffer.from(value, encoding)
     if (!Buffer.isBuffer(buffer)) throw new TypeError('buffer must be a Buffer instance')
+
     if (!offset) offset = 0
     if (offset + length > buffer.length) throw new RangeError('destination buffer is too small')
 

--- a/lib/value.js
+++ b/lib/value.js
@@ -10,8 +10,8 @@ module.exports = function (valueType, value) {
   return {
     encode: function encode (valueParam, buffer, offset) {
       if (valueParam !== undefined) throw new TypeError('Value parameter must be undefined')
+      if (!offset) offset = 0
       if (buffer) {
-        offset = offset | 0
         if ((buffer.length - offset) < encodeLength) throw new RangeError('destination buffer is too small')
         valueBuffer.copy(buffer, offset)
       } else {
@@ -21,7 +21,7 @@ module.exports = function (valueType, value) {
       return buffer
     },
     decode: function decode (target, offset, end) {
-      offset = offset | 0
+      if (!offset) offset = 0
       if (end === undefined) end = target.length
       if (offset + encodeLength > end) throw new RangeError('not enough data for decode')
       if (valueBuffer.compare(target, offset, offset + encodeLength) !== 0) throw new TypeError('Expected value ' + value)

--- a/lib/varbuffer.js
+++ b/lib/varbuffer.js
@@ -32,6 +32,7 @@ module.exports = function (lengthType) {
 
       var length = lengthType.decode(buffer, offset, end)
       offset += lengthType.decode.bytes
+
       if (offset + length > end) throw new RangeError('not enough data for decode')
 
       decode.bytes = (offset + length) - start

--- a/lib/varbuffer.js
+++ b/lib/varbuffer.js
@@ -12,10 +12,11 @@ module.exports = function (lengthType) {
 
   return {
     encode: function encode (value, buffer, offset) {
+      if (!offset) offset = 0
+
       var bytes = _length(value)
       if (!buffer) buffer = Buffer.allocUnsafe(bytes)
       else if ((buffer.length - offset) < bytes) throw new RangeError('destination buffer is too small')
-      if (!offset) offset = 0
 
       lengthType.encode(value.length, buffer, offset)
       offset += lengthType.encode.bytes

--- a/lib/varbuffer.js
+++ b/lib/varbuffer.js
@@ -5,32 +5,39 @@ module.exports = function (lengthType) {
   if (!util.isAbstractCodec(lengthType)) throw new TypeError('lengthType is invalid codec')
 
   function _length (value) {
+    if (!Buffer.isBuffer(value)) throw new TypeError('value must be a Buffer instance')
+
     return lengthType.encodingLength(value.length) + value.length
   }
 
   return {
     encode: function encode (value, buffer, offset) {
-      if (!Buffer.isBuffer(value)) throw new TypeError('value must be a Buffer instance')
-      if (!buffer) buffer = Buffer.allocUnsafe(_length(value))
+      var bytes = _length(value)
+      if (!buffer) buffer = Buffer.allocUnsafe(bytes)
+      else if ((buffer.length - offset) < bytes) throw new RangeError('destination buffer is too small')
       if (!offset) offset = 0
+
       lengthType.encode(value.length, buffer, offset)
       offset += lengthType.encode.bytes
-      if (offset + value.length > buffer.length) throw new RangeError('destination buffer is too small')
-      value.copy(buffer, offset, 0, value.length)
-      encode.bytes = lengthType.encode.bytes + value.length
+
+      value.copy(buffer, offset)
+      encode.bytes = bytes
+
       return buffer
     },
     decode: function decode (buffer, offset, end) {
       if (!offset) offset = 0
       if (!end) end = buffer.length
-      var blength = lengthType.decode(buffer, offset, end)
+      var start = offset
+
+      var length = lengthType.decode(buffer, offset, end)
       offset += lengthType.decode.bytes
-      if (offset + blength > end) throw new RangeError('not enough data for decode')
-      decode.bytes = lengthType.decode.bytes + blength
-      return Buffer.from(buffer.slice(offset, offset + blength))
+      if (offset + length > end) throw new RangeError('not enough data for decode')
+
+      decode.bytes = (offset + length) - start
+      return Buffer.from(buffer.slice(offset, offset + length))
     },
     encodingLength: function encodingLength (value) {
-      if (!Buffer.isBuffer(value)) throw new TypeError('value must be a Buffer instance')
       return _length(value)
     }
   }

--- a/lib/varmap.js
+++ b/lib/varmap.js
@@ -23,11 +23,12 @@ function VarMap (lengthType, keyType, valueType) {
 
   return {
     encode: function encode (object, buffer, offset) {
+      if (!offset) offset = 0
+
       var bytes = _length(object)
       var count = _length.__count
       if (!buffer) buffer = Buffer.allocUnsafe(bytes)
       else if ((buffer.length - offset) < bytes) throw new RangeError('destination buffer is too small')
-      if (!offset) offset = 0
 
       lengthType.encode(count, buffer, offset)
       offset += lengthType.encode.bytes

--- a/lib/varmap.js
+++ b/lib/varmap.js
@@ -50,10 +50,10 @@ function VarMap (lengthType, keyType, valueType) {
       offset += lengthType.encode.bytes
 
       for (var i = 0; i < count; ++i) {
-        var key = keyType.decode(buffer, offset)
+        var key = keyType.decode(buffer, offset, end)
         offset += keyType.decode.bytes
 
-        var value = valueType.decode(buffer, offset)
+        var value = valueType.decode(buffer, offset, end)
         offset += valueType.decode.bytes
 
         result[key] = value

--- a/lib/varstring.js
+++ b/lib/varstring.js
@@ -19,13 +19,13 @@ module.exports = function (lengthType, encoding) {
   return {
     encode: function encode (value, buffer, offset) {
       if (typeof value !== 'string') throw new TypeError('value must be a string')
+      if (!offset) offset = 0
 
       var valueLength = Buffer.byteLength(value, encoding)
       var bytes = lengthType.encodingLength(value.length) + valueLength
 
       if (!buffer) buffer = Buffer.allocUnsafe(bytes)
       else if (!Buffer.isBuffer(buffer)) throw new TypeError('buffer must be a Buffer instance')
-      if (!offset) offset = 0
       if (offset + bytes > buffer.length) throw new RangeError('destination buffer is too small')
 
       lengthType.encode(valueLength, buffer, offset)

--- a/lib/varstring.js
+++ b/lib/varstring.js
@@ -10,6 +10,8 @@ module.exports = function (lengthType, encoding) {
   if (!Buffer.isEncoding(encoding)) throw new TypeError('invalid encoding')
 
   function _length (value) {
+    if (typeof value !== 'string') throw new TypeError('value must be a string')
+
     var valueLength = Buffer.byteLength(value, encoding)
     return lengthType.encodingLength(value.length) + valueLength
   }
@@ -19,27 +21,26 @@ module.exports = function (lengthType, encoding) {
       if (typeof value !== 'string') throw new TypeError('value must be a string')
 
       var valueLength = Buffer.byteLength(value, encoding)
-      var length = lengthType.encodingLength(value.length) + valueLength
+      var bytes = lengthType.encodingLength(value.length) + valueLength
 
-      if (!buffer) buffer = Buffer.allocUnsafe(length)
+      if (!buffer) buffer = Buffer.allocUnsafe(bytes)
       else if (!Buffer.isBuffer(buffer)) throw new TypeError('buffer must be a Buffer instance')
       if (!offset) offset = 0
-      if (offset + length > buffer.length) throw new RangeError('destination buffer is too small')
+      if (offset + bytes > buffer.length) throw new RangeError('destination buffer is too small')
 
       lengthType.encode(valueLength, buffer, offset)
       offset += lengthType.encode.bytes
       buffer.write(value, offset, valueLength, encoding)
 
+      encode.bytes = bytes
       return buffer
     },
     decode: function decode (buffer, offset, end) {
       var string = bufferCodec.decode(buffer, offset, end).toString(encoding)
+
       decode.bytes = bufferCodec.decode.bytes
       return string
     },
-    encodingLength: function encodingLength (value) {
-      if (typeof value !== 'string') throw new TypeError('value must be a string')
-      return _length(value)
-    }
+    encodingLength: _length
   }
 }

--- a/lib/varstring.js
+++ b/lib/varstring.js
@@ -10,7 +10,7 @@ module.exports = function (lengthType, encoding) {
   if (!Buffer.isEncoding(encoding)) throw new TypeError('invalid encoding')
 
   function _length (value) {
-    let valueLength = Buffer.byteLength(value, encoding)
+    var valueLength = Buffer.byteLength(value, encoding)
     return lengthType.encodingLength(value.length) + valueLength
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -12,14 +12,14 @@ test('encode', function (t) {
   t.test('expected object', function (t) {
     t.throws(function () {
       varstruct([length42]).encode()
-    }, /^TypeError: expected value as object, got undefined$/)
+    }, /^TypeError: Expected Object, got undefined$/)
     t.end()
   })
 
   t.test('expected object, not null', function (t) {
     t.throws(function () {
       varstruct([length42]).encode(null)
-    }, /^TypeError: expected value as object, got null$/)
+    }, /^TypeError: Expected Object, got null$/)
     t.end()
   })
 

--- a/test/index.js
+++ b/test/index.js
@@ -8,61 +8,6 @@ var length42 = {
   type: { encode: noop, decode: noop, encodingLength: function () { return 42 } }
 }
 
-test('asserts on codec creation', function (t) {
-  t.test('expected items as Array', function (t) {
-    t.throws(function () {
-      varstruct(null)
-    }, /^TypeError: items must be an Array instance$/)
-    t.end()
-  })
-
-  t.test('missing "name" property', function (t) {
-    t.throws(function () {
-      varstruct([{ foo: 'bar' }])
-    }, /^TypeError: item missing "name" property/)
-    t.end()
-  })
-
-  t.test('type is null', function (t) {
-    t.throws(function () {
-      varstruct([{ name: 'foo', type: null }])
-    }, /^TypeError: item "foo" has invalid codec/)
-    t.end()
-  })
-
-  t.test('type encode should be function', function (t) {
-    t.throws(function () {
-      varstruct([{
-        name: 'foo',
-        type: { encode: null, decode: noop, encodingLength: noop }
-      }])
-    }, /^TypeError: item "foo" has invalid codec/)
-    t.end()
-  })
-
-  t.test('type decode should be function', function (t) {
-    t.throws(function () {
-      varstruct([{
-        name: 'foo',
-        type: { encode: noop, decode: null, encodingLength: noop }
-      }])
-    }, /^TypeError: item "foo" has invalid codec/)
-    t.end()
-  })
-
-  t.test('type encodingLength should be function', function (t) {
-    t.throws(function () {
-      varstruct([{
-        name: 'foo',
-        type: { encode: noop, decode: noop, encodingLength: null }
-      }])
-    }, /^TypeError: item "foo" has invalid codec/)
-    t.end()
-  })
-
-  t.end()
-})
-
 test('encode', function (t) {
   t.test('expected object', function (t) {
     t.throws(function () {
@@ -85,10 +30,6 @@ test('encode', function (t) {
     t.end()
   })
 
-  t.end()
-})
-
-test('decode', function (t) {
   t.end()
 })
 

--- a/test/object.js
+++ b/test/object.js
@@ -96,6 +96,7 @@ test('encode', function (t) {
       'number': 0xfe,
       'foobar': Buffer.alloc(8)
     }, result, 10)
+    t.same(example.encode.bytes, 9)
     t.same(result.slice(10).toString('hex'), 'fe0000000000000000')
 
     t.end()
@@ -123,6 +124,7 @@ test('decode', function (t) {
       'number': 0xfe,
       'foobar': Buffer.alloc(8)
     })
+    t.same(example.decode.bytes, 9)
     t.end()
   })
 

--- a/test/object.js
+++ b/test/object.js
@@ -155,6 +155,23 @@ test('decode', function (t) {
   t.end()
 })
 
+test('encode/decode', function (t) {
+  var type = varstruct([
+    ['a', varstruct.VarString(varstruct.UInt16LE)],
+    ['b', varstruct.VarString(varstruct.UInt8)],
+    ['c', varstruct.Buffer(64)]
+  ])
+
+  let data = {
+    'a': 'foobarbazzz',
+    'b': '',
+    'c': Buffer.alloc(64, 0xff)
+  }
+
+  t.same(data, type.decode(type.encode(data)))
+  t.end()
+})
+
 test('encodingLength', function (t) {
   t.test('value must not be undefined', function (t) {
     t.throws(function () {

--- a/test/object.js
+++ b/test/object.js
@@ -1,0 +1,158 @@
+'use strict'
+var test = require('tape').test
+var varstruct = require('../')
+var example = varstruct([
+  ['number', varstruct.UInt8],
+  ['foobar', varstruct.Buffer(8)]
+])
+
+function noop () {}
+
+test('asserts on codec creation', function (t) {
+  t.test('expected items as Array', function (t) {
+    t.throws(function () {
+      varstruct(null)
+    }, /^TypeError: items must be an Array instance$/)
+    t.end()
+  })
+
+  t.test('missing "name" property', function (t) {
+    t.throws(function () {
+      varstruct([{ foo: 'bar' }])
+    }, /^TypeError: item missing "name" property/)
+    t.end()
+  })
+
+  t.test('type is null', function (t) {
+    t.throws(function () {
+      varstruct([{ name: 'foo', type: null }])
+    }, /^TypeError: item "foo" has invalid codec/)
+    t.end()
+  })
+
+  t.test('type encode should be function', function (t) {
+    t.throws(function () {
+      varstruct([{
+        name: 'foo',
+        type: { encode: null, decode: noop, encodingLength: noop }
+      }])
+    }, /^TypeError: item "foo" has invalid codec/)
+    t.end()
+  })
+
+  t.test('type decode should be function', function (t) {
+    t.throws(function () {
+      varstruct([{
+        name: 'foo',
+        type: { encode: noop, decode: null, encodingLength: noop }
+      }])
+    }, /^TypeError: item "foo" has invalid codec/)
+    t.end()
+  })
+
+  t.test('type encodingLength should be function', function (t) {
+    t.throws(function () {
+      varstruct([{
+        name: 'foo',
+        type: { encode: noop, decode: noop, encodingLength: null }
+      }])
+    }, /^TypeError: item "foo" has invalid codec/)
+    t.end()
+  })
+
+  t.end()
+})
+
+test('encode', function (t) {
+  t.test('destination buffer is too small', function (t) {
+    t.throws(function () {
+      example.encode({
+        'number': 0xfe,
+        'foobar': Buffer.alloc(8)
+      }, Buffer.allocUnsafe(3))
+    }, /^RangeError: destination buffer is too small$/)
+    t.end()
+  })
+
+  t.test('write buffer', function (t) {
+    var result = example.encode({
+      'number': 0xfe,
+      'foobar': Buffer.alloc(8)
+    })
+
+    t.same(example.encode.bytes, 9)
+    t.same(result.toString('hex'), 'fe0000000000000000')
+
+    result.fill(0)
+    example.encode({
+      'number': 0xfe,
+      'foobar': Buffer.alloc(8)
+    }, result, 0)
+    t.same(result.toString('hex'), 'fe0000000000000000')
+
+    // offset > 0 case
+    result = Buffer.alloc(19)
+    example.encode({
+      'number': 0xfe,
+      'foobar': Buffer.alloc(8)
+    }, result, 10)
+    t.same(result.slice(10).toString('hex'), 'fe0000000000000000')
+
+    t.end()
+  })
+
+  t.end()
+})
+
+test('decode', function (t) {
+  t.test('not enough data for decode', function (t) {
+    t.throws(function () {
+      example.decode(Buffer.from('deadbe', 'hex'))
+    }, /^RangeError: not enough data for decode$/)
+    t.end()
+  })
+
+  t.test('extra data for decode', function (t) {
+    example.decode(Buffer.from('fe0000000000000000ffffffffff', 'hex'))
+    t.end()
+  })
+
+  t.test('decode (w/ offset)', function (t) {
+    var result = example.decode(Buffer.from('fffffe0000000000000000', 'hex'), 2)
+    t.same(result, {
+      'number': 0xfe,
+      'foobar': Buffer.alloc(8)
+    })
+    t.end()
+  })
+
+  t.test('not enough data for decode (w/ offset and end)', function (t) {
+    t.throws(function () {
+      example.decode(Buffer.from('fe0000000000000000', 'hex'), 2, 4)
+    }, /^RangeError: not enough data for decode$/)
+    t.end()
+  })
+
+  t.test('read buffers', function (t) {
+    var result = example.decode(Buffer.from('fe0000000000000000', 'hex'))
+    t.same(example.decode.bytes, 9)
+    t.same(result, {
+      'number': 0xfe,
+      'foobar': Buffer.alloc(8)
+    })
+    t.end()
+  })
+
+  t.end()
+})
+
+test('encodingLength', function (t) {
+  t.test('value must not be undefined', function (t) {
+    t.throws(function () {
+      example.encodingLength(null)
+    }, /^TypeError: Expected object/)
+    t.end()
+  })
+
+  t.end()
+})

--- a/test/object.js
+++ b/test/object.js
@@ -176,7 +176,7 @@ test('encodingLength', function (t) {
   t.test('value must not be undefined', function (t) {
     t.throws(function () {
       example.encodingLength(null)
-    }, /^TypeError: Expected object/)
+    }, /^TypeError: Expected Object, got null/)
     t.end()
   })
 

--- a/test/object.js
+++ b/test/object.js
@@ -159,16 +159,19 @@ test('encode/decode', function (t) {
   var type = varstruct([
     ['a', varstruct.VarString(varstruct.UInt16LE)],
     ['b', varstruct.VarString(varstruct.UInt8)],
-    ['c', varstruct.Buffer(64)]
+    ['c', varstruct.Buffer(8)]
   ])
 
   let data = {
     'a': 'foobarbazzz',
     'b': '',
-    'c': Buffer.alloc(64, 0xff)
+    'c': Buffer.alloc(8, 0xff)
   }
 
-  t.same(data, type.decode(type.encode(data)))
+  let buffer = type.encode(data)
+  t.same(type.encode.bytes, 22)
+  t.same(data, type.decode(buffer))
+  t.same(type.decode.bytes, 22)
   t.end()
 })
 

--- a/test/object.js
+++ b/test/object.js
@@ -126,6 +126,13 @@ test('decode', function (t) {
     t.end()
   })
 
+  t.test('enough data for decode, but restricted via end', function (t) {
+    t.throws(function () {
+      example.decode(Buffer.from('fffffe0000000000000000', 'hex'), 0, 4)
+    }, /^RangeError: not enough data for decode$/)
+    t.end()
+  })
+
   t.test('not enough data for decode (w/ offset and end)', function (t) {
     t.throws(function () {
       example.decode(Buffer.from('fe0000000000000000', 'hex'), 2, 4)

--- a/test/varbuffer.js
+++ b/test/varbuffer.js
@@ -31,11 +31,20 @@ test('encode', function (t) {
   })
 
   t.test('write buffer', function (t) {
-    var buf = Buffer.allocUnsafe(42)
+    var buf = Buffer.alloc(42, 0xfe)
     var result = varbuffer.encode(buf)
     t.same(varbuffer.encode.bytes, 46)
-    t.same(result.slice(0, 4).toString('hex'), '0000002a')
-    t.same(result.slice(4).toString('hex'), buf.toString('hex'))
+    t.same(result.toString('hex'), '0000002afefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe')
+
+    result.fill(0)
+    varbuffer.encode(buf, result, 0)
+    t.same(result.toString('hex'), '0000002afefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe')
+
+    // offset > 0 case
+    result.fill(0)
+    varbuffer.encode(Buffer.alloc(32, 0xfe), result, 10)
+    t.same(result.slice(10).toString('hex'), '00000020fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe')
+
     t.end()
   })
 

--- a/test/varmap.js
+++ b/test/varmap.js
@@ -73,7 +73,7 @@ test('encode', function (t) {
     t.end()
   })
 
-  t.test('destination buffer is too small', function (t) {
+  t.test('invalid key', function (t) {
     t.throws(function () {
       example.encode({
         'booooooooo': 0

--- a/test/varmap.js
+++ b/test/varmap.js
@@ -98,6 +98,13 @@ test('decode', function (t) {
     t.end()
   })
 
+  t.test('enough data for decode, but restricted via end', function (t) {
+    t.throws(function () {
+      example.decode(Buffer.from('016667686902', 'hex'), 0, 4)
+    }, /^RangeError: not enough data for decode$/)
+    t.end()
+  })
+
   t.test('not enough data for decode (w/ offset and end)', function (t) {
     t.throws(function () {
       example.decode(Buffer.from('016667686902', 'hex'), 2, 4)

--- a/test/varstring.js
+++ b/test/varstring.js
@@ -46,6 +46,8 @@ test('encode/decode', function (t) {
       var s = randomBytes(1000).toString(encoding)
       var varstring = varstruct.VarString(varstruct.UInt32BE, encoding)
       t.same(varstring.decode(varstring.encode(s)), s)
+      t.same(varstring.encode.bytes, 4 + Buffer.byteLength(s, encoding))
+      t.same(varstring.decode.bytes, 4 + Buffer.byteLength(s, encoding))
       t.end()
     })
   })


### PR DESCRIPTION
Related to https://github.com/varstruct/varstruct/issues/31, https://github.com/varstruct/varstruct/issues/22 and fixes a regression introduced in https://github.com/varstruct/varstruct/pull/30/files#diff-b6c2135f8f43a7663bcc36f099a7dcb2L15 where `encode.bytes` was omitted, and adds test to ensure that will be detected in future.