### PR TITLE
Value should return constant value

### DIFF
--- a/lib/value.js
+++ b/lib/value.js
@@ -10,7 +10,9 @@ module.exports = function (valueType, value) {
 
   return {
     encode: function encode (valueParam, buffer, offset) {
-      if (valueParam !== undefined) throw new TypeError('Value parameter must be undefined')
+      if (valueParam !== undefined &&
+        valueParam !== value) throw new TypeError('Value parameter must be undefined or equal')
+
       if (!offset) offset = 0
       if (buffer) {
         if ((buffer.length - offset) < encodeLength) throw new RangeError('destination buffer is too small')
@@ -18,6 +20,7 @@ module.exports = function (valueType, value) {
       } else {
         buffer = Buffer.from(valueBuffer)
       }
+
       encode.bytes = encodeLength
       return buffer
     },
@@ -32,7 +35,7 @@ module.exports = function (valueType, value) {
       }
 
       decode.bytes = encodeLength
-      return undefined
+      return value
     },
     encodingLength: function encodingLength (valueParam) {
       if (valueParam !== undefined) throw new TypeError('Value parameter must be undefined')

--- a/test/value.js
+++ b/test/value.js
@@ -76,7 +76,7 @@ test('decode', function (t) {
   t.test('read buffers', function (t) {
     var result = value.decode(Buffer.from('deadbeef', 'hex'))
     t.same(value.decode.bytes, 4)
-    t.same(result, undefined)
+    t.same(result, 0xdeadbeef)
     t.end()
   })
 


### PR DESCRIPTION
We were somewhat ambivalent about this in #16,  but in recent usage this has been a pain to have to manually insert into the returned data-structure.

The changed nature of `.encode` accepts `undefined` or the exact value,  which maintains backwards compatability :+1: 

@fanatid ?

IMHO patch version.